### PR TITLE
Feature/input frequency mask

### DIFF
--- a/documentation/validation_log.rst
+++ b/documentation/validation_log.rst
@@ -55,6 +55,10 @@ New Features:
 * midge updated to v3.5.3 (updates scarab to v1.6.0)
 * server_config now only sets the default authentication file path after checking that the path exists
     * tested via docker batch execution with and without the auth file present; detection and setting appears to work fine
+* frequency mask trigger
+    * updated to allow the mask and summed power arrays to be configured, either directly in the configuration file, or with a path to another file (such as that output by the above)
+        * tested in file value arrays by setting in a file and calling write mask to ensure the values are in the output file
+        * tested  from-file by modifying the above output file (so that the values differ), configuring with it as input, and the writing a new output to compare
 
 
 Version: 1.5.0
@@ -70,9 +74,6 @@ New Features:
 * frequency mask trigger
     * updated to also output the summed power data in addition to the spline fit used to define the frequency mask. This goes into a second array in the same output file
         * tested using the egg reader and confirming qualitatively that the mask follows the shape of the accumulated power (after normalizing by the number of accumulated points and the mask's offset)
-    * updated to allow the mask and summed power arrays to be configured, either directly in the configuration file, or with a path to another file (such as that output by the above)
-        * tested in file value arrays by setting in a file and calling write mask to ensure the values are in the output file
-        * tested  from-file by modifying the above output file (so that the values differ), configuring with it as input, and the writing a new output to compare
 * Dripline-cpp updated to v1.6.0
 * CMake option added to allow disabling the FPA on linux builds (useful for batch mode execution without root access).
 * midge updated to v3.5.3 (updates scarab to v1.6.0)

--- a/documentation/validation_log.rst
+++ b/documentation/validation_log.rst
@@ -52,10 +52,13 @@ Release Date: May 8, 2018
 New Features:
 '''''''''''''
 
-* batch_executor retries the reply message's payload and return code; each action happens after the prior one returns (which may not be the conclusion of the action, just like any dripline request)
+* batch_executor receives the reply message's payload and return code; each action happens after the prior one returns (which may not be the conclusion of the action, just like any dripline request)
 * frequency mask trigger
     * updated to also output the summed power data in addition to the spline fit used to define the frequency mask. This goes into a second array in the same output file
-    * tested using the egg reader and confirming qualitatively that the mask follows the shape of the accumulated power (after normalizing by the number of accumulated points and the mask's offset)
+        * tested using the egg reader and confirming qualitatively that the mask follows the shape of the accumulated power (after normalizing by the number of accumulated points and the mask's offset)
+    * updated to allow the mask and summed power arrays to be configured, either directly in the configuration file, or with a path to another file (such as that output by the above)
+        * will test in-file by setting in a file and calling write mask to ensure the values are in the output file
+        * will test the from-file by modifying the above file, configuring with it as input, and the writing a new output to compare
 * Dripline-cpp updated to v1.6.0
 * CMake option added to allow disabling the FPA on linux builds (useful for batch mode execution without root access).
 

--- a/documentation/validation_log.rst
+++ b/documentation/validation_log.rst
@@ -57,8 +57,8 @@ New Features:
     * updated to also output the summed power data in addition to the spline fit used to define the frequency mask. This goes into a second array in the same output file
         * tested using the egg reader and confirming qualitatively that the mask follows the shape of the accumulated power (after normalizing by the number of accumulated points and the mask's offset)
     * updated to allow the mask and summed power arrays to be configured, either directly in the configuration file, or with a path to another file (such as that output by the above)
-        * will test in-file by setting in a file and calling write mask to ensure the values are in the output file
-        * will test the from-file by modifying the above file, configuring with it as input, and the writing a new output to compare
+        * tested in file value arrays by setting in a file and calling write mask to ensure the values are in the output file
+        * tested  from-file by modifying the above output file (so that the values differ), configuring with it as input, and the writing a new output to compare
 * Dripline-cpp updated to v1.6.0
 * CMake option added to allow disabling the FPA on linux builds (useful for batch mode execution without root access).
 

--- a/source/daq/frequency_mask_trigger.cc
+++ b/source/daq/frequency_mask_trigger.cc
@@ -112,16 +112,23 @@ namespace psyllid
         }
     }
 
-    void frequency_mask_trigger::set_mask_and_data_vectors( scarab::param_node* a_mask_and_data_values )
+    void frequency_mask_trigger::set_mask_and_data_vectors( const scarab::param_node* a_mask_and_data_values )
     {
         // grab the new arrays
-        scarab::param_array* t_new_mask = a_mask_and_data_values->array_at( "mask_data" );
-        scarab::param_array* t_new_mask_data = a_mask_and_data_values->array_at( "mask" );
+        const scarab::param_array* t_new_mask = a_mask_and_data_values->array_at( "mask_data" );
+        const scarab::param_array* t_new_mask_data = a_mask_and_data_values->array_at( "mask" );
         if ( t_new_mask == NULL || t_new_mask_data == NULL ) throw psyllid::error() << "new mask and mask data must not be null";
+        // prep the data members
         f_mask.clear();
         f_mask_data.clear();
         f_mask.resize( t_new_mask->size() );
         f_mask_data.resize( t_new_mask_data->size() );
+        // assign new values
+        for( unsigned i_bin = 0; i_bin < t_new_mask->size(); ++i_bin )
+        {
+            f_mask[ i_bin ] = t_new_mask->value_at( i_bin )->as_double();
+            f_mask_data[ i_bin ] = t_new_mask_data->value_at( i_bin )->as_double();
+        }
     }
 
     void frequency_mask_trigger::switch_to_update_mask()
@@ -803,6 +810,36 @@ namespace psyllid
         {
             a_node->set_trigger_mode( a_config.get_value< std::string >( "trigger-mode" ) );
         }
+        if( a_config.has( "mask-configuration" ) )
+        {
+            const scarab::param* t_mask_config = a_config.at( "mask-configuration" );
+            if ( t_mask_config->is_value() )
+            {
+                scarab::param_input_codec* t_yaml_codec = scarab::factory< scarab::param_input_codec >::get_instance()->create( "yaml" );
+                if (t_yaml_codec == nullptr )
+                {
+                    throw error() << "Unable to create input-codec for YAML";
+                }
+                //TODO read_file doesn't seem to use any other members, could it be static? Would that let me avoid the factory thing above and let the implementation of read_file deal with deciding on the codec to use?
+                scarab::param* t_file_param = t_yaml_codec->read_file( t_mask_config->as_value().as_string(), NULL );
+                if ( t_file_param->is_node() )
+                {
+                    a_node->set_mask_and_data_vectors( &(t_file_param->as_node()) );
+                }
+                else
+                {
+                    throw psyllid::error() << "mask file must be anode";
+                }
+            }
+            else if ( t_mask_config->is_node() )
+            {
+                a_node->set_mask_and_data_vectors( &(t_mask_config->as_node()) );
+            }
+            else
+            {
+                throw psyllid::error() << "invalid config: mask-configuration must be a file path or a node with mask and mask-data";
+            }
+        }
 
         a_node->set_length( a_config.get_value( "length", a_node->get_length() ) );
         return;
@@ -817,6 +854,8 @@ namespace psyllid
         a_config.add( "threshold-power-snr-high", new scarab::param_value( a_node->get_threshold_snr_high() ) );
         a_config.add( "length", new scarab::param_value( a_node->get_length() ) );
         a_config.add( "trigger-mode", new scarab::param_value( a_node->get_trigger_mode_str() ) );
+        //TODO these are potentially large, do we want to include the mask and mask-data in this dump? (they also have an existing write to file option)
+        //a_config.add( "mask-configuration", new scarab::param_node( a_node->get_mask_configuration() ) );
         return;
     }
 

--- a/source/daq/frequency_mask_trigger.cc
+++ b/source/daq/frequency_mask_trigger.cc
@@ -117,7 +117,7 @@ namespace psyllid
         // grab the new arrays
         const scarab::param_array* t_new_mask = a_mask_and_data_values->array_at( "mask" );
         const scarab::param_array* t_new_mask_data = a_mask_and_data_values->array_at( "mask-data" );
-        if ( t_new_mask == NULL || t_new_mask_data == NULL ) throw psyllid::error() << "new mask and mask data must not be null";
+        if ( t_new_mask == nullptr || t_new_mask_data == nullptr ) throw psyllid::error() << "new mask and mask data must not be null";
         // prep the data members
         f_mask.clear();
         f_mask_data.clear();
@@ -821,7 +821,7 @@ namespace psyllid
                 {
                     throw error() << "Unable to create input-codec for YAML";
                 }
-                scarab::param* t_file_param = t_yaml_codec->read_file( t_mask_config->as_value().as_string(), NULL );
+                scarab::param* t_file_param = t_yaml_codec->read_file( t_mask_config->as_value().as_string() );
                 if ( t_file_param->is_node() )
                 {
                     a_node->set_mask_and_data_vectors( &(t_file_param->as_node()) );

--- a/source/daq/frequency_mask_trigger.cc
+++ b/source/daq/frequency_mask_trigger.cc
@@ -112,6 +112,17 @@ namespace psyllid
         }
     }
 
+    void frequency_mask_trigger::set_mask_and_data_vectors( scarab::param_node* a_mask_and_data_values )
+    {
+        // grab the new arrays
+        scarab::param_array* t_new_mask = a_mask_and_data_values->array_at( "mask_data" );
+        scarab::param_array* t_new_mask_data = a_mask_and_data_values->array_at( "mask" );
+        if ( t_new_mask == NULL || t_new_mask_data == NULL ) throw psyllid::error() << "new mask and mask data must not be null";
+        f_mask.clear();
+        f_mask_data.clear();
+        f_mask.resize( t_new_mask->size() );
+        f_mask_data.resize( t_new_mask_data->size() );
+    }
 
     void frequency_mask_trigger::switch_to_update_mask()
     {

--- a/source/daq/frequency_mask_trigger.cc
+++ b/source/daq/frequency_mask_trigger.cc
@@ -828,7 +828,7 @@ namespace psyllid
                 }
                 else
                 {
-                    throw psyllid::error() << "mask file must be anode";
+                    throw psyllid::error() << "mask file must be a node";
                 }
             }
             else if ( t_mask_config->is_node() )

--- a/source/daq/frequency_mask_trigger.cc
+++ b/source/daq/frequency_mask_trigger.cc
@@ -115,8 +115,8 @@ namespace psyllid
     void frequency_mask_trigger::set_mask_and_data_vectors( const scarab::param_node* a_mask_and_data_values )
     {
         // grab the new arrays
-        const scarab::param_array* t_new_mask = a_mask_and_data_values->array_at( "mask_data" );
-        const scarab::param_array* t_new_mask_data = a_mask_and_data_values->array_at( "mask" );
+        const scarab::param_array* t_new_mask = a_mask_and_data_values->array_at( "mask" );
+        const scarab::param_array* t_new_mask_data = a_mask_and_data_values->array_at( "mask-data" );
         if ( t_new_mask == NULL || t_new_mask_data == NULL ) throw psyllid::error() << "new mask and mask data must not be null";
         // prep the data members
         f_mask.clear();
@@ -812,6 +812,7 @@ namespace psyllid
         }
         if( a_config.has( "mask-configuration" ) )
         {
+            //TODO is this an okay place for this logic, or should it go in the fmt class itself or in a private method of this class?
             const scarab::param* t_mask_config = a_config.at( "mask-configuration" );
             if ( t_mask_config->is_value() )
             {
@@ -820,7 +821,6 @@ namespace psyllid
                 {
                     throw error() << "Unable to create input-codec for YAML";
                 }
-                //TODO read_file doesn't seem to use any other members, could it be static? Would that let me avoid the factory thing above and let the implementation of read_file deal with deciding on the codec to use?
                 scarab::param* t_file_param = t_yaml_codec->read_file( t_mask_config->as_value().as_string(), NULL );
                 if ( t_file_param->is_node() )
                 {

--- a/source/daq/frequency_mask_trigger.hh
+++ b/source/daq/frequency_mask_trigger.hh
@@ -104,7 +104,7 @@ namespace psyllid
             void set_threshold_dB( double a_dB );
             void set_trigger_mode( const std::string& trigger_mode );
             std::string get_trigger_mode_str() const;
-            void set_mask_and_data_vectors( scarab::param_node* a_mask_and_data_values );
+            void set_mask_and_data_vectors( const scarab::param_node* a_mask_and_data_values );
 
             mv_accessible( uint64_t, length );
             mv_accessible_noset( unsigned, n_packets_for_mask );

--- a/source/daq/frequency_mask_trigger.hh
+++ b/source/daq/frequency_mask_trigger.hh
@@ -104,6 +104,7 @@ namespace psyllid
             void set_threshold_dB( double a_dB );
             void set_trigger_mode( const std::string& trigger_mode );
             std::string get_trigger_mode_str() const;
+            void set_mask_and_data_vectors( scarab::param_node* a_mask_and_data_values );
 
             mv_accessible( uint64_t, length );
             mv_accessible_noset( unsigned, n_packets_for_mask );

--- a/source/daq/frequency_mask_trigger.hh
+++ b/source/daq/frequency_mask_trigger.hh
@@ -64,6 +64,7 @@ namespace psyllid
      - "threshold-dB": float -- The threshold SNR, given as a dB factor
      - "trigger-mode": string -- The trigger mode, can be set to "single-level-trigger" or "two-level-trigger"
      - "n-spline-points": uint -- The number of points to have in the spline fit for the trigger mask
+     - "mask-configuration": string || node -- If a string, path to a yaml file with mask and mask-data arrays to populate the respective vectors; if a node, then contains those arrays of floats.
 
      Available DAQ commands:
      - "update-mask" (no args) -- Switch the execution mode to updating the trigger mask


### PR DESCRIPTION
In addition to anything you find, I have the following questions:
1) Should `frequency_mask_trigger_binding::do_dump_config` include dumping the mask data, since those are configurable? The con being that it adds two arrays of 4096 floats each, which is messy (and may break dripline-python by producing payloads that are too big, if that's still a thing). The pro being that it is configurable, and this would make it easier to fully restore the FMT state. Another option would be to return the other params and also dump the FM and FM-data to some hard coded path (in /tmp?), there could even be a `mask-configuration: /tmp/mask_dump.yaml` entry in the dump to match.
2) In `frequency_mask_trigger_binding::do_apply_config` I ended up implementing quite a bit of logic to deal with cases for providing a string path vs a node of arrays of values. Should this be moved elsewhere (a helper function in binding, into the FMT class, something else)?

For each I should either make a change or remove the `//TODO` comment.

Edit:
This resolves #67 