### PR TITLE
Feature/get stream and node list

### DIFF
--- a/documentation/server_api.rst
+++ b/documentation/server_api.rst
@@ -121,6 +121,22 @@ Please note that this action will not necessarily return the value in use (e.g. 
 
 - ``[parameter name]: [value]`` -- Parameter name and value
 
+``stream-list``
+---------------
+Returns a list of all streams in the psyllid instance
+
+*Reply Payload*
+
+- ``streams: [[stream_name (string)]]`` -- array of names of the streams
+
+``node-list.[stream]``
+----------------------
+Returns a list of all the nodes in the indicated stream
+
+*Reply Payload*
+
+- ``nodes: [[node_name (string)]]`` -- array of names of the nodes
+
 ``filename.[file_number (optional)]``
 ------------
 Returns the filename that will be written to by writters registered to ``file_number``.  Default for ``file_number`` is 0.

--- a/documentation/validation_log.rst
+++ b/documentation/validation_log.rst
@@ -40,6 +40,19 @@ Fixes:
 * Fix 2
     * Details
 
+Upcoming Release:
+~~~~~~~~~~~~~~~~~
+
+New Features:
+'''''''''''''
+
+* stream_manager methods for OP_GET of stream and node lists
+    * methods added to stream_manager, with extra get bindings in run_server
+    * tested by getting each from a running psyllid instance in insectarium and confirming:
+        * get stream-list: returns streams
+        * get node-list: returns error (need to specify a stream)
+        * get node-list.ch0: returns nodes
+
 Log
 ---
 

--- a/source/control/run_server.cc
+++ b/source/control/run_server.cc
@@ -137,6 +137,8 @@ namespace psyllid
         f_request_receiver->register_get_handler( "description", std::bind( &daq_control::handle_get_description_request, f_daq_control, _1, _2 ) );
         f_request_receiver->register_get_handler( "duration", std::bind( &daq_control::handle_get_duration_request, f_daq_control, _1, _2 ) );
         f_request_receiver->register_get_handler( "use-monarch", std::bind( &daq_control::handle_get_use_monarch_request, f_daq_control, _1, _2 ) );
+        f_request_receiver->register_get_handler( "stream-list", std::bind( &stream_manager::handle_get_stream_list_request, f_stream_manager, _1, _2 ) );
+        f_request_receiver->register_get_handler( "node-list", std::bind( &stream_manager::handle_get_stream_node_list_request, f_stream_manager, _1, _2 ) );
 
         // add set request handlers
         f_request_receiver->register_set_handler( "node-config", std::bind( &stream_manager::handle_configure_node_request, f_stream_manager, _1, _2 ) );

--- a/source/control/stream_manager.cc
+++ b/source/control/stream_manager.cc
@@ -636,14 +636,14 @@ namespace psyllid
 
         if( !f_streams.count( t_target_stream ) )
         {
-            return a_reply_pkg.send_reply( dripline::retcode_t::message_error_invalid_key, "RKS is improperly formatted: [queue].node-config.[stream]" );
+            return a_reply_pkg.send_reply( dripline::retcode_t::message_error_invalid_key, "RKS is improperly formatted: [queue].node-list.[stream]" );
         }
         stream_manager::stream_template::nodes_t* t_these_nodes = &(f_streams[ t_target_stream ].f_nodes);
 
-        scarab::param_array t_node_list = scarab::param_array();
         LDEBUG( plog, "Getting list of nodes from the stream handler" );
         try
         {
+            scarab::param_array t_node_list;
             for ( stream_manager::stream_template::nodes_t::iterator t_nodes_it = t_these_nodes->begin(); t_nodes_it != t_these_nodes->end(); ++t_nodes_it )
             {
                 t_node_list.push_back( scarab::param_value( t_nodes_it->first ) );

--- a/source/control/stream_manager.hh
+++ b/source/control/stream_manager.hh
@@ -99,6 +99,8 @@ namespace psyllid
 
             dripline::reply_info handle_configure_node_request( const dripline::request_ptr_t a_request, dripline::reply_package& a_reply_pkg );
             dripline::reply_info handle_dump_config_node_request( const dripline::request_ptr_t a_request, dripline::reply_package& a_reply_pkg );
+            dripline::reply_info handle_get_stream_list_request( const dripline::request_ptr_t a_request, dripline::reply_package& a_reply_pkg );
+            dripline::reply_info handle_get_stream_node_list_request( const dripline::request_ptr_t a_request, dripline::reply_package& a_reply_pkg );
 
         private:
             void _add_stream( const std::string& a_name, const scarab::param_node* a_node );


### PR DESCRIPTION
@wcpettus can you confirm that this does what you need, example output is this:

```
root@a57727a7ef4b:/# dragonfly get -b rabbit_broker psyllid_reader.stream-list
warning: slack is only ever warning, setting that
psyllid_reader.stream-list(ret:0): [unknown]-> {u'streams': [u'ch0']}

root@a57727a7ef4b:/# dragonfly get -b rabbit_broker psyllid_reader.node-list
warning: slack is only ever warning, setting that
psyllid_reader.node-list(ret:308): [unknown]-> {}
2018-06-27T21:45:13[Level 25] dragonfly.subcommands.dripline_agent(87) -> return message: RKS is improperly formatted: [queue].node-config.[stream]

root@a57727a7ef4b:/# dragonfly get -b rabbit_broker psyllid_reader.node-list.ch0
warning: slack is only ever warning, setting that
psyllid_reader.node-list.ch0(ret:0): [unknown]-> {u'nodes': [u'e3r', u'ft', u'strfw', u'strw']}
```

Note:
this resolves #83 