### PR TITLE
Feature/write skip tolerance

### DIFF
--- a/documentation/validation_log.rst
+++ b/documentation/validation_log.rst
@@ -44,6 +44,20 @@ Fixes:
 Log
 ---
 
+Upcoming Release:
+~~~~~~~~~~~~~~~~~~~
+
+Release Date:
+'''''''''''''
+
+New Features:
+'''''''''''''
+
+* ids in skip_buffer are written as true when event_builder switches from skipping to untriggered
+    * as before, if capacity of skip_buffer is greater than capacity of pretrigger_buffer only ids that don't fit into pretrigger_buffer are written out as true
+    * if capacity of skip_buffer is smaller than capacity of pretrigger_buffer all ids in skip_buffer are written out as true
+
+
 Version 1.7.0:
 ~~~~~~~~~~~~~~~~~
 

--- a/documentation/validation_log.rst
+++ b/documentation/validation_log.rst
@@ -53,8 +53,9 @@ New Features:
 '''''''''''''
 
 * ids in skip_buffer are written as true when event_builder switches from skipping to untriggered
-    * as before, if capacity of skip_buffer is greater than capacity of pretrigger_buffer only ids that don't fit into pretrigger_buffer are written out as true
-    * if capacity of skip_buffer is smaller than capacity of pretrigger_buffer all ids in skip_buffer are written out as true
+    * as before, if the capacity of the skip_buffer is greater than the capacity of the pretrigger_buffer only ids that don't fit into pretrigger_buffer are written out as true
+    * if the capacity of the skip_buffer is smaller than the capacity of the pretrigger_buffer all ids in the skip_buffer are written out as true
+    * tested by running psyllid with the egg3-reader and checking the logging output. No crash occured and the looging output showed that the correct number of ids were written.
 * implementing support for both set_condition and batch actions:
     * server_config now defines condition 10 and 12, both call the cmd 'hard-abort'
     * server_config now defines a top-level node 'batch-commands' with an entry for 'hard-abort' which calls 'stop-run'

--- a/source/daq/event_builder.cc
+++ b/source/daq/event_builder.cc
@@ -330,29 +330,47 @@ namespace psyllid
                             if(f_skip_buffer.full() )
                             {
                                 LINFO( plog, "Skip_tolerance reached. Continuing as untriggered");
-                                // write out ids as false that are only in the skip buffer
-                                while( f_skip_buffer.size() > f_pretrigger_buffer.size() )
+                                // if skip buffer is not bigger than pretrigger buffer, write out ids as true
+                                if ( f_skip_buffer.capacity() <= f_pretrigger_buffer.capacity() )
                                 {
-                                    LTRACE( plog, "Current state skipping. Writing id " << f_skip_buffer.front() << " as true" );
-                                    
-                                    if( ! write_output_from_skipbuff_front( true, t_write_flag ) )
+                                    while( ! f_skip_buffer.empty() )
                                     {
-                                        goto exit_outer_loop;
+                                        LTRACE( plog, "Current state skipping. Writing id " << f_skip_buffer.front() << " as true" );
+                                        if( ! write_output_from_skipbuff_front( true, t_write_flag ) )
+                                        {
+                                            goto exit_outer_loop;
+                                        }
+                                        // advance our output data pointer to the next in the stream
+                                        t_write_flag = out_stream< 0 >().data();
+                                        f_pretrigger_buffer.pop_front();
                                     }
-                                    // advance our output data pointer to the next in the stream
-                                    t_write_flag = out_stream< 0 >().data();
                                 }
-                                // then delete the remaining content of the skip buffer
-                                f_skip_buffer.clear();
-
-                                // contents of the buffer are the existing pretrigger plus the current trig id
-                                // only write out from the front of the buffer if the buffer is full; otherwise we're filling the buffer
-                                if( f_pretrigger_buffer.full() )
+                                else
                                 {
-                                    LTRACE( plog, "Current state skipping. Writing id "<<f_pretrigger_buffer.front()<<" as false");
-                                    if( ! write_output_from_ptbuff_front( false, t_write_flag ) )
+                                    // write out ids as true that are only in the skip buffer
+                                    while( f_skip_buffer.size() > f_pretrigger_buffer.size() )
                                     {
-                                        break;
+                                        LTRACE( plog, "Current state skipping. Writing id " << f_skip_buffer.front() << " as true" );
+
+                                        if( ! write_output_from_skipbuff_front( true, t_write_flag ) )
+                                        {
+                                            goto exit_outer_loop;
+                                        }
+                                        // advance our output data pointer to the next in the stream
+                                        t_write_flag = out_stream< 0 >().data();
+                                    }
+                                    // then delete the remaining content of the skip buffer
+                                    f_skip_buffer.clear();
+
+                                    // contents of the buffer are the existing pretrigger plus the current trig id
+                                    // only write out from the front of the buffer if the buffer is full; otherwise we're filling the buffer
+                                    if( f_pretrigger_buffer.full() )
+                                    {
+                                        LTRACE( plog, "Current state skipping. Writing id "<<f_pretrigger_buffer.front()<<" as false");
+                                        if( ! write_output_from_ptbuff_front( false, t_write_flag ) )
+                                        {
+                                            break;
+                                        }
                                     }
                                 }
                                 // set state to untriggered


### PR DESCRIPTION
addressing issue #82 (sort of)

The skip_buffer is still used both in waiting (for n-triggers) and in skipping status.
I think that is ok as both rely on the same sort of activity per time to either start writing or keep writing.
Instead I changed that, at the end of an acquisition, the entire skip_buffer content is emptied as true if the skip_buffer is smaller than the pretrigger_buffer.

When we developed the logic for the event-builder I had long tracks with a good enough snr in mind. Therefore I thought that the skip_buffer would always be longer than the pretrigger_buffer. 

But instead we have a low SNR (-> events mostly start before trigger) and we want to record short tracks.
It's quite possible that we'll want the skip-tolerance to be shorter than the pretrigger-time. Without the changes in this branch, a single trigger would then result in only the pretirgger_buffer being written out and we would not see what was going on after the trigger.