### PR TITLE
Feature/set condition

### DIFF
--- a/documentation/server_api.rst
+++ b/documentation/server_api.rst
@@ -50,6 +50,16 @@ Requests that the server lockout be disabled.
 --------
 Check that the server receives requests and sends replies. No other action is taken.
 
+``set_condition``
+-----------------
+Cause the server to move to some defined state as quickly as possible; Psyllid implements conditions 10 and 12, both of which stop any ongoing run.
+_Note:_ set_condition is expected to be a broadcast command (routing key target is `broadcast` not `<psyllid-queue>`).
+
+
+*Payload*
+
+- ``values=[condition (int)]`` -- the integer condition
+
 
 Psyllid API
 ===========
@@ -314,3 +324,9 @@ Put in its deactivated state, in which it is not immediately ready to take data.
 ``quit-psyllid``
 ----------------
 Instruct the Psyllid executable to exit.
+
+<batch-command-key>
+-------------------
+All keys listed in the `batch-commands` node of the configuration are bound as command names and may be called.
+These add one or more commands to the batch_executor queue; the return code indicates only that the actions were queued, nothing about their execution status.
+The command `hard-abort` is defined in the default server_config to execute `stop-run`.

--- a/documentation/validation_log.rst
+++ b/documentation/validation_log.rst
@@ -40,6 +40,30 @@ Fixes:
 * Fix 2
     * Details
 
+Version <upcoming>
+~~~~~~~~~~~~~~~~~~
+
+Release Date: <TBD>
+'''''''''''''''''''
+
+New Features:
+'''''''''''''
+
+* implementing support for both set_condition and batch actions:
+    * server_config now defines condition 10 and 12, both call the cmd 'hard-abort'
+    * server_config now defines a top-level node 'batch-commands' with an entry for 'hard-abort' which calls 'stop-run'
+    * request_receiver stores the above map (configurable in config file as top-level node 'set-conditions'); responds to set-condition commands by calling the mapped rks as an OP_CMD with empty message body
+    * batch_executor stores the batch-commands map (each entry in the node is an array of commands following the same syntax as those run when the system starts
+    * batch_executor's constructor binds request-receiver commands for each key in the above map to do_batch_cmd_request, which adds the configured array of actions to the batch queue. This is called as `agent cmd <queue>.<key>`.
+    * batch_executor's execute() method now has an infinite loop option which always tries to empty a concurrent_queue of actions (there are now utility methods plus the above which can populate that queue.
+    * run_server's thread execution logic changed to account for the above changes to batch_executor's execute()
+    * the 'batch-actions' top-level node name is changed to 'on-startup' to be more clear
+    * tested by running psyllid in insectarium and confirming execution of stop run both on `cmd broadcast.set_condition 0` and `cmd psyllid_queue.hard-abort`.
+
+Fixes:
+''''''
+
+* corrected compiler warnings related to use of '%u' vs '%lu' for long unsigned ints in testing
 
 Log
 ---

--- a/source/control/batch_executor.cc
+++ b/source/control/batch_executor.cc
@@ -86,8 +86,7 @@ namespace psyllid
               action_it!=actions_array->end();
               ++action_it )
         {
-            //TODO reduce or remove
-            LWARN( plog, "adding an item: " << (*action_it)->as_node())
+            LDEBUG( plog, "adding an item: " << (*action_it)->as_node())
             add_to_queue( &((*action_it)->as_node()) );
         }
     }
@@ -167,8 +166,6 @@ namespace psyllid
             if ( is_canceled() ) break;
             if ( f_action_queue.size() )
             {
-                //TODO remove or lower level
-                LWARN( plog, "there are: >= " << f_action_queue.size() << " actions remaining" );
                 do_an_action();
             }
         }

--- a/source/control/batch_executor.cc
+++ b/source/control/batch_executor.cc
@@ -33,12 +33,11 @@ namespace psyllid
     }
 
     batch_executor::batch_executor( const scarab::param_node& a_master_config, std::shared_ptr<psyllid::request_receiver> a_request_receiver ) :
-        f_batch_commands( ),
+        f_batch_commands( *(a_master_config.node_at( "batch-commands" )) ),
         f_request_receiver( a_request_receiver ),
         f_action_queue(),
         f_condition_actions()
     {
-        f_batch_commands.merge( *(a_master_config.node_at( "batch-commands" )) );
         if ( a_master_config.has( "batch-actions" ) )
         {
             LINFO( plog, "have an initial action array" );

--- a/source/control/batch_executor.cc
+++ b/source/control/batch_executor.cc
@@ -48,6 +48,9 @@ namespace psyllid
             LINFO( plog, "initial batch array is null" );
             //f_actions_array = scarab::param_array();
         }
+        if ( a_master_config.has( "settable-conditions" ) )
+        {
+        }
     }
 
     batch_executor::~batch_executor()
@@ -80,33 +83,16 @@ namespace psyllid
             duration: 200
             filenames: '["/tmp/foo_t.yaml", "/tmp/foo_f.yaml"]'
     */
-    void batch_executor::execute()
+    void batch_executor::execute( bool run_forever )
     {
-        // start with a sleep... is request_receiver ready?
-        //TODO this sleep should not be needed here, if something isn't ready, run control should call execute when it is
-        std::this_thread::sleep_for( std::chrono::milliseconds( 500 ) );
-        /*
-        if ( f_actions_array.is_null() )
-        {
-            LINFO( plog, "actions array is null" );
-            return;
-        }
-        */
-
-        LDEBUG( plog, "initial actions queue size is: " << f_action_queue.size() );
-        while ( f_action_queue.size() )
+        while ( run_forever || f_action_queue.size() )
         {
             if ( is_canceled() ) break;
             if ( f_action_queue.size() )
             {
                 //TODO remove or lower level
-                LWARN( plog, "there are: <" << f_action_queue.size() << "> actions remaining" );
+                LWARN( plog, "there are: >= " << f_action_queue.size() << " actions remaining" );
                 do_an_action();
-            }
-            else
-            {
-                //TODO is this desired, do other controllers sleep?
-                std::this_thread::sleep_for( std::chrono::milliseconds( 100 ) );
             }
         }
 

--- a/source/control/batch_executor.cc
+++ b/source/control/batch_executor.cc
@@ -38,7 +38,7 @@ namespace psyllid
         f_action_queue(),
         f_condition_actions()
     {
-        if ( a_master_config.has( "batch-actions" ) )
+        if ( a_master_config.has( "on-startup" ) )
         {
             LINFO( plog, "have an initial action array" );
             add_to_queue( a_master_config.array_at( "batch-actions" ) );

--- a/source/control/batch_executor.cc
+++ b/source/control/batch_executor.cc
@@ -98,6 +98,24 @@ namespace psyllid
         }
     }
 
+    void batch_executor::replace_queue( const scarab::param_node* an_action )
+    {
+        clear_queue();
+        add_to_queue( an_action );
+    }
+
+    void batch_executor::replace_queue( const scarab::param_array* actions_array )
+    {
+        clear_queue();
+        add_to_queue( actions_array );
+    }
+
+    void batch_executor::replace_queue( const std::string a_batch_command_name )
+    {
+        clear_queue();
+        add_to_queue( a_batch_command_name );
+    }
+
     /* considering yaml that looks like:
     batch-actions:
         - type: cmd

--- a/source/control/batch_executor.cc
+++ b/source/control/batch_executor.cc
@@ -122,7 +122,8 @@ namespace psyllid
         add_to_queue( a_batch_command_name );
     }
 
-    dripline::reply_info batch_executor::do_batch_cmd_request( const std::string& a_command, const dripline::request_ptr_t a_request_ptr_t, dripline::reply_package& a_reply_package )
+    // this method should be bound in the request receiver to be called with a command name, the request_ptr_t is not used
+    dripline::reply_info batch_executor::do_batch_cmd_request( const std::string& a_command, const dripline::request_ptr_t /* a_request_ptr_t */, dripline::reply_package& a_reply_package )
     {
         try
         {
@@ -135,7 +136,8 @@ namespace psyllid
         return a_reply_package.send_reply( dripline::retcode_t::success, "" );
     }
 
-    dripline::reply_info batch_executor::do_replace_actions_request( const std::string& a_command, const dripline::request_ptr_t a_request_ptr_t, dripline::reply_package& a_reply_package )
+    // this method should be bound in the request receiver to be called with a command name, the request_ptr_t is not used
+    dripline::reply_info batch_executor::do_replace_actions_request( const std::string& a_command, const dripline::request_ptr_t /* a_request_ptr_t */, dripline::reply_package& a_reply_package )
     {
         try
         {

--- a/source/control/batch_executor.cc
+++ b/source/control/batch_executor.cc
@@ -24,32 +24,33 @@ namespace psyllid
     LOGGER( plog, "batch_executor" );
 
     batch_executor::batch_executor() :
-        //f_actions_array(),
         f_request_receiver(),
-        f_action_queue()
+        f_action_queue(),
+        f_condition_actions()
     {
     }
 
     batch_executor::batch_executor( const scarab::param_node& a_master_config, std::shared_ptr<psyllid::request_receiver> a_request_receiver ) :
-        //f_actions_array(),
         f_request_receiver( a_request_receiver ),
-        f_action_queue()
+        f_action_queue(),
+        f_condition_actions()
     {
         if ( a_master_config.has( "batch-actions" ) )
         {
             LINFO( plog, "have an initial action array" );
-            //f_actions_array = *(a_master_config.array_at( "batch-actions" ));
             add_to_queue( a_master_config.array_at( "batch-actions" ) );
-            //TODO REMOVE
-            LINFO( plog, "queue size is: " << f_action_queue.size());
         }
         else
         {
-            LINFO( plog, "initial batch array is null" );
-            //f_actions_array = scarab::param_array();
+            LINFO( plog, "no initial batch actions" );
         }
         if ( a_master_config.has( "settable-conditions" ) )
         {
+            LINFO( plog, "storing setable conditions mapping" );
+            if ( !a_master_config.node_at( "settable-conditions" ) ) {
+                // settable-conditions is not a node, throw an exception
+            }
+            //f_condition_actions = *(a_master_config.node_at( "settable-conditions" ).clone());
         }
     }
 

--- a/source/control/batch_executor.cc
+++ b/source/control/batch_executor.cc
@@ -57,7 +57,7 @@ namespace psyllid
 
         // register batch commands
         using namespace std::placeholders;
-        for ( scarab::param_node::iterator command_it = f_batch_commands.begin(); command_it != f_batch_commands.end(); command_it++ )
+        for ( scarab::param_node::iterator command_it = f_batch_commands.begin(); command_it != f_batch_commands.end(); ++command_it )
         {
             a_request_receiver->register_cmd_handler( command_it->first, std::bind( &batch_executor::do_batch_cmd_request, this, command_it->first, _1, _2 ) );
         }
@@ -91,7 +91,7 @@ namespace psyllid
         }
     }
 
-    void batch_executor::add_to_queue( const std::string a_batch_command_name )
+    void batch_executor::add_to_queue( const std::string& a_batch_command_name )
     {
         if ( f_batch_commands.has( a_batch_command_name ) )
         {
@@ -115,7 +115,7 @@ namespace psyllid
         add_to_queue( actions_array );
     }
 
-    void batch_executor::replace_queue( const std::string a_batch_command_name )
+    void batch_executor::replace_queue( const std::string& a_batch_command_name )
     {
         clear_queue();
         add_to_queue( a_batch_command_name );

--- a/source/control/batch_executor.cc
+++ b/source/control/batch_executor.cc
@@ -24,21 +24,21 @@ namespace psyllid
     LOGGER( plog, "batch_executor" );
 
     batch_executor::batch_executor() :
-        f_actions_array(),
+        //f_actions_array(),
         f_request_receiver(),
         f_action_queue()
     {
     }
 
     batch_executor::batch_executor( const scarab::param_node& a_master_config, std::shared_ptr<psyllid::request_receiver> a_request_receiver ) :
-        f_actions_array(),
+        //f_actions_array(),
         f_request_receiver( a_request_receiver ),
         f_action_queue()
     {
         if ( a_master_config.has( "batch-actions" ) )
         {
             LINFO( plog, "have an initial action array" );
-            f_actions_array = *(a_master_config.array_at( "batch-actions" ));
+            //f_actions_array = *(a_master_config.array_at( "batch-actions" ));
             add_to_queue( a_master_config.array_at( "batch-actions" ) );
             //TODO REMOVE
             LINFO( plog, "queue size is: " << f_action_queue.size());
@@ -46,7 +46,7 @@ namespace psyllid
         else
         {
             LINFO( plog, "initial batch array is null" );
-            f_actions_array = scarab::param_array();
+            //f_actions_array = scarab::param_array();
         }
     }
 
@@ -83,19 +83,31 @@ namespace psyllid
     void batch_executor::execute()
     {
         // start with a sleep... is request_receiver ready?
+        //TODO this sleep should not be needed here, if something isn't ready, run control should call execute when it is
         std::this_thread::sleep_for( std::chrono::milliseconds( 500 ) );
+        /*
         if ( f_actions_array.is_null() )
         {
             LINFO( plog, "actions array is null" );
             return;
         }
+        */
 
-        LDEBUG( plog, "actions array size is: " << f_actions_array.size() );
+        LDEBUG( plog, "initial actions queue size is: " << f_action_queue.size() );
         while ( f_action_queue.size() )
         {
             if ( is_canceled() ) break;
-            do_an_action();
-
+            if ( f_action_queue.size() )
+            {
+                //TODO remove or lower level
+                LWARN( plog, "there are: <" << f_action_queue.size() << "> actions remaining" );
+                do_an_action();
+            }
+            else
+            {
+                //TODO is this desired, do other controllers sleep?
+                std::this_thread::sleep_for( std::chrono::milliseconds( 100 ) );
+            }
         }
 
         LINFO( plog, "action loop complete" );

--- a/source/control/batch_executor.hh
+++ b/source/control/batch_executor.hh
@@ -15,6 +15,7 @@
 
 // dripline
 #include "message.hh"
+#include "reply_package.hh"
 
 namespace psyllid
 {
@@ -67,6 +68,9 @@ namespace psyllid
             void replace_queue( const scarab::param_node* an_action );
             void replace_queue( const scarab::param_array* actions_array );
             void replace_queue( const std::string a_batch_command_name );
+
+            dripline::reply_info do_batch_cmd_request( const std::string&, const dripline::request_ptr_t, dripline::reply_package& );
+            dripline::reply_info do_replace_actions_request( const std::string&, const dripline::request_ptr_t, dripline::reply_package& );
 
             void execute( bool run_forever = false );
 

--- a/source/control/batch_executor.hh
+++ b/source/control/batch_executor.hh
@@ -10,6 +10,7 @@
 
 // scarab includes
 #include "cancelable.hh"
+#include "concurrent_queue.hh"
 #include "param.hh"
 
 // dripline
@@ -56,11 +57,17 @@ namespace psyllid
             batch_executor( const scarab::param_node& a_master_config, std::shared_ptr<psyllid::request_receiver> a_request_receiver );
             virtual ~batch_executor();
 
+            void add_to_queue( const scarab::param_node* an_action );
+            void add_to_queue( const scarab::param_array* actions_array );
+
             void execute();
 
         private:
             scarab::param_array f_actions_array;
             std::shared_ptr<request_receiver> f_request_receiver;
+            scarab::concurrent_queue< action_info > f_action_queue;
+
+            void do_an_action();
 
             virtual void do_cancellation();
             static action_info parse_action( const scarab::param_node* a_action );

--- a/source/control/batch_executor.hh
+++ b/source/control/batch_executor.hh
@@ -63,7 +63,7 @@ namespace psyllid
             void execute();
 
         private:
-            scarab::param_array f_actions_array;
+            //scarab::param_array f_actions_array;
             std::shared_ptr<request_receiver> f_request_receiver;
             scarab::concurrent_queue< action_info > f_action_queue;
 

--- a/source/control/batch_executor.hh
+++ b/source/control/batch_executor.hh
@@ -64,6 +64,9 @@ namespace psyllid
             void add_to_queue( const scarab::param_node* an_action );
             void add_to_queue( const scarab::param_array* actions_array );
             void add_to_queue( const std::string a_batch_command_name );
+            void replace_queue( const scarab::param_node* an_action );
+            void replace_queue( const scarab::param_array* actions_array );
+            void replace_queue( const std::string a_batch_command_name );
 
             void execute( bool run_forever = false );
 

--- a/source/control/batch_executor.hh
+++ b/source/control/batch_executor.hh
@@ -57,8 +57,13 @@ namespace psyllid
             batch_executor( const scarab::param_node& a_master_config, std::shared_ptr<psyllid::request_receiver> a_request_receiver );
             virtual ~batch_executor();
 
+            mv_accessible( scarab::param_node, batch_commands );
+
+        public:
+            void clear_queue();
             void add_to_queue( const scarab::param_node* an_action );
             void add_to_queue( const scarab::param_array* actions_array );
+            void add_to_queue( const std::string a_batch_command_name );
 
             void execute( bool run_forever = false );
 

--- a/source/control/batch_executor.hh
+++ b/source/control/batch_executor.hh
@@ -64,10 +64,10 @@ namespace psyllid
             void clear_queue();
             void add_to_queue( const scarab::param_node* an_action );
             void add_to_queue( const scarab::param_array* actions_array );
-            void add_to_queue( const std::string a_batch_command_name );
+            void add_to_queue( const std::string& a_batch_command_name );
             void replace_queue( const scarab::param_node* an_action );
             void replace_queue( const scarab::param_array* actions_array );
-            void replace_queue( const std::string a_batch_command_name );
+            void replace_queue( const std::string& a_batch_command_name );
 
             dripline::reply_info do_batch_cmd_request( const std::string&, const dripline::request_ptr_t, dripline::reply_package& );
             dripline::reply_info do_replace_actions_request( const std::string&, const dripline::request_ptr_t, dripline::reply_package& );

--- a/source/control/batch_executor.hh
+++ b/source/control/batch_executor.hh
@@ -58,7 +58,7 @@ namespace psyllid
             batch_executor( const scarab::param_node& a_master_config, std::shared_ptr<psyllid::request_receiver> a_request_receiver );
             virtual ~batch_executor();
 
-            mv_accessible( scarab::param_node, batch_commands );
+            mv_referrable_const( scarab::param_node, batch_commands );
 
         public:
             void clear_queue();

--- a/source/control/batch_executor.hh
+++ b/source/control/batch_executor.hh
@@ -63,9 +63,9 @@ namespace psyllid
             void execute( bool run_forever = false );
 
         private:
-            //scarab::param_array f_actions_array;
             std::shared_ptr<request_receiver> f_request_receiver;
             scarab::concurrent_queue< action_info > f_action_queue;
+            scarab::param_node f_condition_actions;
 
             void do_an_action();
 

--- a/source/control/batch_executor.hh
+++ b/source/control/batch_executor.hh
@@ -60,7 +60,7 @@ namespace psyllid
             void add_to_queue( const scarab::param_node* an_action );
             void add_to_queue( const scarab::param_array* actions_array );
 
-            void execute();
+            void execute( bool run_forever = false );
 
         private:
             //scarab::param_array f_actions_array;

--- a/source/control/request_receiver.cc
+++ b/source/control/request_receiver.cc
@@ -1,5 +1,6 @@
 
 #include "request_receiver.hh"
+#include "dripline_constants.hh"
 
 #include "psyllid_error.hh"
 
@@ -105,5 +106,9 @@ namespace psyllid
         }
     }
 
+    dripline::reply_info request_receiver::__do_handle_set_condition_request( const dripline::request_ptr_t a_request, dripline::reply_package& a_reply_pkg )
+    {
+        return a_reply_pkg.send_reply( dripline::retcode_t::success, "" );
+    }
 
 }

--- a/source/control/request_receiver.cc
+++ b/source/control/request_receiver.cc
@@ -28,6 +28,7 @@ namespace psyllid
     request_receiver::request_receiver( const param_node& a_master_config ) :
             hub( a_master_config.node_at( "amqp" ) ),
             scarab::cancelable(),
+            f_set_conditions( *(a_master_config.node_at( "set-conditions" )) ),
             f_status( k_initialized )
     {
     }
@@ -108,7 +109,17 @@ namespace psyllid
 
     dripline::reply_info request_receiver::__do_handle_set_condition_request( const dripline::request_ptr_t a_request, dripline::reply_package& a_reply_pkg )
     {
-        return a_reply_pkg.send_reply( dripline::retcode_t::success, "" );
+        std::string t_condition = std::to_string(a_request->get_payload().array_at( "values" )->get_value< unsigned >( 0 ));
+        if ( f_set_conditions.has( t_condition ) )
+        {
+            std::string t_rks = f_set_conditions.get_value( t_condition );
+            dripline::request_ptr_t t_request = dripline::msg_request::create( new scarab::param_node(), dripline::op_t::cmd, std::string(), std::string() );
+            t_request->set_routing_key_specifier( t_rks, dripline::routing_key_specifier( t_rks ) );
+
+            dripline::reply_info t_reply_info = submit_request_message( t_request );
+            return a_reply_pkg.send_reply( t_reply_info.f_return_code, t_reply_info.f_return_msg );
+        }
+        return a_reply_pkg.send_reply( dripline::retcode_t::daq_error, "set condition not configured" );
     }
 
 }

--- a/source/control/request_receiver.hh
+++ b/source/control/request_receiver.hh
@@ -37,6 +37,7 @@ namespace psyllid
 
             void execute();
 
+            mv_accessible_noset( scarab::param_node, set_conditions );
         private:
             virtual void do_cancellation();
 

--- a/source/control/request_receiver.hh
+++ b/source/control/request_receiver.hh
@@ -37,7 +37,7 @@ namespace psyllid
 
             void execute();
 
-            mv_accessible_noset( scarab::param_node, set_conditions );
+            mv_referrable_const( scarab::param_node, set_conditions );
         private:
             virtual void do_cancellation();
 

--- a/source/control/request_receiver.hh
+++ b/source/control/request_receiver.hh
@@ -1,7 +1,10 @@
 #ifndef PSYLLID_REQUEST_RECEIVER_HH_
 #define PSYLLID_REQUEST_RECEIVER_HH_
 
+// dripline
 #include "hub.hh"
+#include "message.hh"
+#include "reply_package.hh"
 
 #include "param.hh"
 
@@ -55,6 +58,7 @@ namespace psyllid
 
         private:
             std::atomic< status > f_status;
+            virtual dripline::reply_info __do_handle_set_condition_request( const dripline::request_ptr_t a_request, dripline::reply_package& a_reply_pkg );
 
     };
 

--- a/source/control/run_server.cc
+++ b/source/control/run_server.cc
@@ -171,8 +171,8 @@ namespace psyllid
         LPROG( plog, "Running..." );
 
         std::thread t_executor_thread( &batch_executor::execute, f_batch_executor.get() );
-        t_executor_thread.join();
-        LDEBUG( plog, "batch executions complete" );
+        //t_executor_thread.join();
+        //LDEBUG( plog, "batch executions complete" );
 
         t_receiver_thread.join();
         LPROG( plog, "Receiver thread has ended" );
@@ -181,6 +181,8 @@ namespace psyllid
             LINFO( plog, "request receiver not making connections, canceling run server" );
             this->cancel();
         }
+        t_executor_thread.join();
+        LDEBUG( plog, "batch executions complete" );
         t_daq_control_thread.join();
         LPROG( plog, "DAQ control thread has ended" );
 

--- a/source/control/server_config.cc
+++ b/source/control/server_config.cc
@@ -16,6 +16,7 @@
 
 using std::string;
 
+using scarab::param_array;
 using scarab::param_node;
 using scarab::param_value;
 
@@ -60,6 +61,21 @@ namespace psyllid
         t_daq_node->add( "duration", new param_value( 1000U ) );
         t_daq_node->add( "max-file-size-mb", new param_value( 500.0 ) );
         add( "daq", t_daq_node );
+
+        param_node* t_batch_commands = new param_node();
+        param_array* t_stop_array = new param_array();
+        param_node* t_stop_action = new param_node();
+        t_stop_action->add( "type", new param_value( "cmd" ) );
+        t_stop_action->add( "rks", new param_value( "stop-run" ) );
+        t_stop_action->add( "payload", new param_node() );
+        t_stop_array->push_back( t_stop_action );
+        t_batch_commands->add( "hard-abort", t_stop_array );
+        add( "batch-commands",  t_batch_commands );
+
+        param_node* t_set_conditions = new param_node();
+        t_set_conditions->add( "10", new param_value( "hard-abort" ) );
+        t_set_conditions->add( "12", new param_value( "hard-abort" ) );
+        add( "set-conditions", t_set_conditions );
 
         /*
         // this devices node can be used for multiple streams

--- a/source/control/server_config.cc
+++ b/source/control/server_config.cc
@@ -62,6 +62,7 @@ namespace psyllid
         t_daq_node->add( "max-file-size-mb", new param_value( 500.0 ) );
         add( "daq", t_daq_node );
 
+        //TODO clean this up in scarab2
         param_node* t_batch_commands = new param_node();
         param_array* t_stop_array = new param_array();
         param_node* t_stop_action = new param_node();

--- a/source/test/test_tpacket_v3.cc
+++ b/source/test/test_tpacket_v3.cc
@@ -144,7 +144,7 @@ static void display(tpacket3_hdr *ppd)
         getnameinfo((sockaddr *) &sd, sizeof(sd),
                 dbuff, sizeof(dbuff), NULL, 0, NI_NUMERICHOST);
 
-        if( packets_total % 1000 == 0 ) printf("packet %u; bytes read: %u; %s -> %s\n", packets_total, bytes_total, sbuff, dbuff);
+        if( packets_total % 1000 == 0 ) printf("packet %lu; bytes read: %lu; %s -> %s\n", packets_total, bytes_total, sbuff, dbuff);
     }
 
     //printf("rxhash: 0x%x\n", ppd->hv1.tp_rxhash);


### PR DESCRIPTION
expands batch_executor to support queuing actions while running. Includes bindings for calling sets of actions by name and mapping from set_condition values to running any viable RKS as a CMD (with empty payload).

Note: resolves #45 and #79 